### PR TITLE
fix: showReplayControls seeking Chrome bug

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -585,7 +585,9 @@ export default class VideoRecorder extends Component {
   }
 
   handleDurationChange = () => {
-    this.props.showReplayControls ? this.replayVideo.currentTime = 1000000 : null
+    if (this.props.showReplayControls) {
+      this.replayVideo.currentTime = 1000000
+    }
   }
 
   renderCameraView () {

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -584,6 +584,10 @@ export default class VideoRecorder extends Component {
     })
   }
 
+  handleDurationChange = () => {
+    this.props.showReplayControls ? this.replayVideo.currentTime = 1000000 : null
+  }
+
   renderCameraView () {
     const {
       showReplayControls,
@@ -633,6 +637,7 @@ export default class VideoRecorder extends Component {
             autoPlay
             controls={showReplayControls}
             onClick={this.handleReplayVideoClick}
+            onDurationChange={this.handleDurationChange}
           />
           {videoInput}
         </CameraView>


### PR DESCRIPTION
When the finished video is more than ~2 seconds, there is a [Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=642012) that when MediaRecorder produces and assembles webm chunks, you can't seek through the file because the duration is incorrect until the last few seconds. One of the [suggested solutions](https://stackoverflow.com/questions/38062864/blob-video-duration-metadata) to this bug that is now marked as "Won't fix" is to set the currentTime on the video element to the integer max value when the incorrect duration is first set by listening to the durationChanged event. This will cause the video player to jump to the end of the video, "discovering" the video length. Because of looping and autoplay, the video restarts at the beginning, plays normally, and is now fully seekable.