### PR TITLE
feat: add isFlipped prop

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -76,6 +76,8 @@ export default class VideoRecorder extends Component {
   static propTypes = {
     /** Whether or not to start the camera initially */
     isOnInitially: PropTypes.bool,
+    /** Whether or not to display the video flipped (makes sense for user facing camera) */
+    isFlipped: PropTypes.bool,
     /** Pass this if you want to force a specific mime-type for the video */
     mimeType: PropTypes.string,
     /** How much time to wait until it starts recording (in ms) */
@@ -119,6 +121,7 @@ export default class VideoRecorder extends Component {
     renderDisconnectedView: () => <DisconnectedView />,
     renderLoadingView: () => <LoadingView />,
     renderActions,
+    isFlipped: true,
     countdownTime: 3000,
     constraints: CONSTRAINTS,
     chunkSize: 250,
@@ -661,7 +664,12 @@ export default class VideoRecorder extends Component {
     if (isCameraOn) {
       return (
         <CameraView key='camera'>
-          <Video isFlipped ref={el => (this.cameraVideo = el)} autoPlay muted />
+          <Video
+            isFlipped={this.props.isFlipped}
+            ref={el => (this.cameraVideo = el)}
+            autoPlay
+            muted
+          />
         </CameraView>
       )
     }

--- a/src/video-recorder.stories.js
+++ b/src/video-recorder.stories.js
@@ -85,3 +85,7 @@ stories.add('without dataAvailableTimeout', () => (
 stories.add('with showReplayControls=true', () => (
   <VideoRecorder isOnInitially showReplayControls {...actionLoggers} />
 ))
+
+stories.add('with isFlipped=false', () => (
+  <VideoRecorder isFlipped={false} showReplayControls {...actionLoggers} />
+))


### PR DESCRIPTION
This adds the option to turn off flipping the image.

When the camera is facing the environment instead of the user, for example when recording a video with your phone, the hardcoded flipped camera feed is very confusing (pans the opposite direction that the user pans the phone). Ideally it detects which camera (user or environment) is used and flips the image accordingly. But at least having the option to turn off flipping, for the use case of recording the environment, is a solution for now. What do you think?