### PR TITLE
feat: Add replayVideoAutoplayAndLoopOff

### DIFF
--- a/src/defaults/render-actions.js
+++ b/src/defaults/render-actions.js
@@ -32,6 +32,7 @@ const Actions = ({
   countdownTime,
   timeLimit,
   showReplayControls,
+  replayVideoAutoplayAndLoopOff,
   useVideoInput,
 
   onTurnOnCamera,
@@ -115,6 +116,7 @@ Actions.propTypes = {
   countdownTime: PropTypes.number,
   timeLimit: PropTypes.number,
   showReplayControls: PropTypes.bool,
+  replayVideoAutoplayAndLoopOff: PropTypes.bool,
   isReplayingVideo: PropTypes.bool,
   useVideoInput: PropTypes.bool,
 

--- a/src/video-recorder.stories.js
+++ b/src/video-recorder.stories.js
@@ -85,3 +85,16 @@ stories.add('without dataAvailableTimeout', () => (
 stories.add('with showReplayControls=true', () => (
   <VideoRecorder isOnInitially showReplayControls {...actionLoggers} />
 ))
+
+stories.add(
+  'with showReplayControls=true replayVideoAutoplayAndLoopOff=true',
+  () => (
+    <VideoRecorder
+      isOnInitially
+      showReplayControls
+      replayVideoAutoplayAndLoopOff
+      isReplayVideoInitiallyMuted={false}
+      {...actionLoggers}
+    />
+  )
+)

--- a/src/video-recorder.stories.js
+++ b/src/video-recorder.stories.js
@@ -86,7 +86,6 @@ stories.add('with showReplayControls=true', () => (
   <VideoRecorder isOnInitially showReplayControls {...actionLoggers} />
 ))
 
-
 stories.add(
   'with showReplayControls=true replayVideoAutoplayAndLoopOff=true',
   () => (


### PR DESCRIPTION
- Added a prop `replayVideoAutoplayAndLoopOff` that will stop the replay video from autoplaying and looping. If you set this prop to true, it is recommended that you also set `showReplayControls` to true so that the replay video can be controlled somehow
- Fixes a related bug from a [previous PR](https://github.com/fbaiodias/react-video-recorder/pull/30)  where `showReplayControls` won't work properly when clicked because the component code is interfering with the native controls
- Added `replayVideoAutoplayAndLoopOff` to render-actions and Storybook

edit: tests passed