### PR TITLE
fix: actions overlay blocking video controls

### DIFF
--- a/src/defaults/render-actions.js
+++ b/src/defaults/render-actions.js
@@ -9,14 +9,12 @@ import Countdown from './countdown'
 
 const ActionsWrapper = styled.div`
   position: absolute;
-  bottom: 0;
   left: 0;
   right: 0;
+  top: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-top: 20px;
-  padding-bottom: 80px;
 `
 
 const Actions = ({


### PR DESCRIPTION
This fix aligns the Action wrapper to the top, hence it stops blocking video controls.

https://github.com/fbaiodias/react-video-recorder/issues/38