### PR TITLE
hotfix: fixes a bug on iPhone where it doesn't save the recorded video on the second time (if you press the 'Use another video' button)

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -595,6 +595,9 @@ export default class VideoRecorder extends Component {
 
     this.videoInput.current.value = null
     this.videoInput.current.click()
+
+    // fixes a bug on iPhone where it doesn't save the recorded video on the second time (if you press the 'Use another video' button)
+    this.videoInput.current.addEventListener('change', this.handleVideoSelected)
   }
 
   handleStopReplaying = () => {


### PR DESCRIPTION
Hello!

I'm using this lib on a project and we had this bug where if an iphone user tries to discard the recorded video on the lib (using 'use another video' button, not the 'retake' option on the native camera on iphone), the second video he records wasn't being saved (the this.handleVideoSelected wasn't being called).

So I made a fix for this problem.