### PR TITLE
chore: support older browsers

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -522,6 +522,11 @@ export default class VideoRecorder extends Component {
 
   // see https://bugs.chromium.org/p/chromium/issues/detail?id=642012
   fixVideoMetadata = (rawVideoBlob) => {
+    // see https://stackoverflow.com/a/63568311
+    Blob.prototype.arrayBuffer ??= function () {
+      return new Response(this).arrayBuffer()
+    }
+
     return rawVideoBlob.arrayBuffer().then((buffer) => {
       const decoder = new Decoder()
       const elements = decoder.decode(buffer)


### PR DESCRIPTION
When running inside Microsoft Teams, `arrayBuffer()` did not work, because internally Teams is using chrome v69. Adding a polyfill to make it work on older browsers fixed the problem.