### PR TITLE
fix: Errors when VideoRecorder is unmounted while setting up

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -285,13 +285,17 @@ export default class VideoRecorder extends Component {
   handleError = (err) => {
     const { onError } = this.props
 
-    console.error('Captured error', err)
-
-    clearTimeout(this.timeLimitTimeout)
-
     if (onError) {
       onError(err)
     }
+
+    if (this.isComponentUnmounted) {
+      return
+    }
+
+    console.error('Captured error', err)
+
+    clearTimeout(this.timeLimitTimeout)
 
     this.setState({
       isConnecting: this.state.isConnecting && false,

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -134,6 +134,8 @@ export default class VideoRecorder extends Component {
 
   videoInput = React.createRef()
 
+  isComponentUnmounted = false
+
   timeSinceInactivity = 0
 
   state = {
@@ -196,6 +198,7 @@ export default class VideoRecorder extends Component {
 
   componentWillUnmount () {
     this.turnOffCamera()
+    this.isComponentUnmounted = true
   }
 
   turnOnCamera = () => {
@@ -247,6 +250,12 @@ export default class VideoRecorder extends Component {
   }
 
   handleSuccess = (stream) => {
+    // Since handleSuccess is an async function, we may be in a situation where this was called after the
+    // component was unmounted
+    if (this.isComponentUnmounted) {
+      return
+    }
+
     this.stream = stream
     this.setState({
       isCameraOn: true,


### PR DESCRIPTION
If the VideoRecorder component is unmounted quickly after it's mounted, `handleSuccess` will still be executed but result in a couple errors. Once when it calls `setState`, and another time when it tries to update `this.cameraVideo.srcObject`.

Here are the two errors I've seen in this scenario:
Captured error TypeError: Cannot set property 'srcObject' of undefined video-recorder.js:201

Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in VideoRecorder