### PR TITLE
fix: support added to allow recording on iOS Safari

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -22,7 +22,8 @@ const MIME_TYPES = [
   'video/webm;codecs="vp8,opus"',
   'video/webm;codecs=h264',
   'video/webm;codecs=vp9',
-  'video/webm'
+  'video/webm',
+  'video/mp4'
 ]
 
 const CONSTRAINTS = {
@@ -383,7 +384,7 @@ export default class VideoRecorder extends Component {
       ? MIME_TYPES.find(window.MediaRecorder.isTypeSupported)
       : 'video/webm'
 
-    return mimeType || ''
+    return (this.mediaRecorder && this.mediaRecorder.mimeType) || mimeType || ''
   }
 
   isDataHealthOK = (event) => {
@@ -593,6 +594,10 @@ export default class VideoRecorder extends Component {
 
   // see https://bugs.chromium.org/p/chromium/issues/detail?id=642012
   fixVideoMetadata = (rawVideoBlob) => {
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+    if (isSafari) {
+      return Promise.resolve(rawVideoBlob)
+    }
     // see https://stackoverflow.com/a/63568311
     Blob.prototype.arrayBuffer ??= function () {
       return new Response(this).arrayBuffer()

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -324,14 +324,12 @@ export default class VideoRecorder extends Component {
       this.props.onCameraOn()
     }
 
-    if (this.state.isCameraOn) {
-      setTimeout(() => {
-        if (window.URL) {
-          this.cameraVideo.srcObject = stream
-        } else {
-          this.cameraVideo.src = stream
-        }
-      }, 200)
+    if (this.cameraVideo) {
+      if (window.URL) {
+        this.cameraVideo.srcObject = stream
+      } else {
+        this.cameraVideo.src = stream
+      }
     }
 
     // there is probably a better way

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -324,10 +324,14 @@ export default class VideoRecorder extends Component {
       this.props.onCameraOn()
     }
 
-    if (window.URL) {
-      this.cameraVideo.srcObject = stream
-    } else {
-      this.cameraVideo.src = stream
+    if (this.state.isCameraOn) {
+      setTimeout(() => {
+        if (window.URL) {
+          this.cameraVideo.srcObject = stream
+        } else {
+          this.cameraVideo.src = stream
+        }
+      }, 200)
     }
 
     // there is probably a better way

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -799,6 +799,7 @@ export default class VideoRecorder extends Component {
             ref={(el) => (this.cameraVideo = el)}
             autoPlay
             muted
+            playsInline
           />
           {switchCameraControl}
         </CameraView>


### PR DESCRIPTION

 Changes:
 * we use window.MediaSource to check if inline recording is supported but that is not used anywhere in the code.
 * window.MediaSource is not supported in ios on safari as well
 * Updated the condition to check only if MediaRecorder and mediaDevices are supported to check for inline recording
 * Related to: https://github.com/fbaiodias/react-video-recorder/issues/104