### PR TITLE
fix: disable camera switch on single video source

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -784,7 +784,7 @@ export default class VideoRecorder extends Component {
     if (isCameraOn) {
       // Enable switch camera button, only if not recording and multiple video sources available
       const switchCameraControl =
-        availableDeviceIds && availableDeviceIds.length >= 1 && !isRecording ? (
+        availableDeviceIds && availableDeviceIds.length >= 2 && !isRecording ? (
           <SwitchCameraView onClick={this.handleSwitchCamera} />
         ) : null
 


### PR DESCRIPTION
previously the camera switch button was always shown. Even on devices with a single camera