### PR TITLE
Fixing ts-EBML `Schema Unknown`

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -605,7 +605,10 @@ export default class VideoRecorder extends Component {
 
     return rawVideoBlob.arrayBuffer().then((buffer) => {
       const decoder = new Decoder()
-      const elements = decoder.decode(buffer)
+      let elements = decoder.decode(buffer)
+      // see https://github.com/legokichi/ts-ebml/issues/33#issuecomment-888800828
+      var validEmlType = ['m', 'u', 'i', 'f', 's', '8', 'b', 'd'];
+      elements = elements?.filter((elm) => validEmlType.includes(elm.type))
 
       const reader = new Reader()
       reader.logging = false

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -607,7 +607,7 @@ export default class VideoRecorder extends Component {
       const decoder = new Decoder()
       let elements = decoder.decode(buffer)
       // see https://github.com/legokichi/ts-ebml/issues/33#issuecomment-888800828
-      var validEmlType = ['m', 'u', 'i', 'f', 's', '8', 'b', 'd'];
+      const validEmlType = ['m', 'u', 'i', 'f', 's', '8', 'b', 'd'];
       elements = elements?.filter((elm) => validEmlType.includes(elm.type))
 
       const reader = new Reader()


### PR DESCRIPTION
Fixing error where element schema is unknown. Currently breaking `react-video-recorder` in Chrome latest.

Workaround is from https://github.com/legokichi/ts-ebml/issues/33#issuecomment-888800828

Issue: https://github.com/fbaiodias/react-video-recorder/issues/130