### PR TITLE
fix: ts-ebml problem

### DIFF
--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -609,7 +609,10 @@ export default class VideoRecorder extends Component {
 
     return rawVideoBlob.arrayBuffer().then((buffer) => {
       const decoder = new Decoder()
-      const elements = decoder.decode(buffer)
+      let elements = decoder.decode(buffer)
+      // see https://github.com/legokichi/ts-ebml/issues/33#issuecomment-888800828
+      const validEmlType = ['m', 'u', 'i', 'f', 's', '8', 'b', 'd']
+      elements = elements?.filter((elm) => validEmlType.includes(elm.type))
 
       const reader = new Reader()
       reader.logging = false


### PR DESCRIPTION
Replaces #131 with the commit message fixed. 

From the original PR description:
> Fixing error where element schema is unknown. Currently breaking react-video-recorder in Chrome latest.
> Workaround is from legokichi/ts-ebml#33 (comment)
> Issue: #130

Thanks @catoenm!

EDIT: fixes #127 